### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -1,5 +1,6 @@
 {
        "name" : "WebService::HazIP",
+       "license" : "Artistic-2.0",
        "version" : "1.0.0",
        "description" : "Simple web service client that queries the canihazip.com web site, to obtain the host's public facing IP address.",
        "author" : "Michael",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license